### PR TITLE
Set policy CMP0167 to avoid warnings with CMake 3.30

### DIFF
--- a/.github/workflows/conda/environment_windows.yml
+++ b/.github/workflows/conda/environment_windows.yml
@@ -16,5 +16,6 @@ dependencies:
   - qhull
   - cmake
   - ccache
+  - cxx-compiler
   - pkg-config
   - ninja

--- a/.github/workflows/windows-conda-clang.yml
+++ b/.github/workflows/windows-conda-clang.yml
@@ -42,7 +42,6 @@ jobs:
     - name: Build Coal
       shell: cmd /C CALL {0}
       run: |
-        call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64
         call conda list
         :: Tell Ninja to use clang-cl
         set CC=clang-cl

--- a/.github/workflows/windows-conda-clang.yml
+++ b/.github/workflows/windows-conda-clang.yml
@@ -55,7 +55,6 @@ jobs:
         cmake ^
           -G "Ninja" ^
           -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library ^
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ^
           -DCMAKE_BUILD_TYPE=Release ^
           -DGENERATE_PYTHON_STUBS=ON ^
           -DPYTHON_SITELIB=%CONDA_PREFIX%\Lib\site-packages ^

--- a/.github/workflows/windows-conda-clang.yml
+++ b/.github/workflows/windows-conda-clang.yml
@@ -43,6 +43,7 @@ jobs:
       shell: cmd /C CALL {0}
       run: |
         call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64
+        call conda list
         :: Tell Ninja to use clang-cl
         set CC=clang-cl
         set CXX=clang-cl
@@ -65,7 +66,7 @@ jobs:
         if errorlevel 1 exit 1
 
         :: Build and Install
-        cmake --build . --config Release --target install
+        ninja install -v
         if errorlevel 1 exit 1
 
         :: Testing

--- a/.github/workflows/windows-conda-v142.yml
+++ b/.github/workflows/windows-conda-v142.yml
@@ -41,7 +41,6 @@ jobs:
     - name: Build Coal
       shell: cmd /C CALL {0}
       run: |
-        call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64
         call conda list
 
         :: Create build

--- a/.github/workflows/windows-conda-v142.yml
+++ b/.github/workflows/windows-conda-v142.yml
@@ -42,6 +42,7 @@ jobs:
       shell: cmd /C CALL {0}
       run: |
         call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64
+        call conda list
 
         :: Create build
         mkdir build
@@ -62,7 +63,7 @@ jobs:
         if errorlevel 1 exit 1
 
         :: Build and Install
-        cmake --build . --config Release --target install
+        ninja install -v
         if errorlevel 1 exit 1
 
         :: Testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix issue in Octomap.computeLocalAABB
 - Fix unsupported function for contact_patch_matrix
 - Fix Octomap dependency on ROS
+- Remove CMake CMP0167 warnings
 
 ## [2.4.4] - 2024-03-06
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,12 @@ else()
   endif()
 endif()
 
+
+# Use BoostConfig module distributed by boost library instead of using FindBoost module distributed
+# by CMake
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
 include("${JRL_CMAKE_MODULES}/boost.cmake")
 include("${JRL_CMAKE_MODULES}/python.cmake")
 include("${JRL_CMAKE_MODULES}/hpp.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,9 +92,9 @@ endif()
 
 # Use BoostConfig module distributed by boost library instead of using FindBoost module distributed
 # by CMake
-if(POLICY CMP0167)
-  cmake_policy(SET CMP0167 NEW)
-endif()
+# if(POLICY CMP0167)
+#   cmake_policy(SET CMP0167 NEW)
+# endif()
 include("${JRL_CMAKE_MODULES}/boost.cmake")
 include("${JRL_CMAKE_MODULES}/python.cmake")
 include("${JRL_CMAKE_MODULES}/hpp.cmake")


### PR DESCRIPTION
CMake 3.30 don't package anymore the FindBoost.cmake file. Instead, it encourage to use the BoostModule.cmake distributed by Boost.

To avoid a warning message, we must set the CMP0167 policy to NEW.