### PR TITLE
Coal more compat

### DIFF
--- a/hpp-fclConfig.cmake
+++ b/hpp-fclConfig.cmake
@@ -3,4 +3,15 @@
 message(WARNING "Please update your CMake from 'hpp-fcl' to 'coal'")
 
 find_package(coal REQUIRED)
-add_library(hpp-fcl::hpp-fcl ALIAS coal::coal)
+
+if(CMAKE_VERSION VERSION_LESS "3.18.0")
+  if(NOT TARGET hpp-fcl::hpp-fcl)
+    add_library(hpp-fcl::hpp-fcl SHARED IMPORTED)
+    target_link_libraries(hpp-fcl::hpp-fcl INTERFACE coal::coal)
+    get_property(_cfg TARGET coal::coal PROPERTY IMPORTED_CONFIGURATIONS)
+    get_property(_loc TARGET coal::coal PROPERTY "IMPORTED_LOCATION_${_cfg}")
+    set_property(TARGET hpp-fcl::hpp-fcl PROPERTY IMPORTED_LOCATION "${_loc}")
+  endif()
+else()
+  add_library(hpp-fcl::hpp-fcl ALIAS coal::coal)
+endif()

--- a/include/hpp/fcl/coal.hpp
+++ b/include/hpp/fcl/coal.hpp
@@ -1,15 +1,19 @@
-#ifndef HPP_FCL_COAL_HH
-#define HPP_FCL_COAL_HH
+#ifndef HPP_FCL_COAL_HPP
+#define HPP_FCL_COAL_HPP
 
 #include <coal/config.hh>
 #include <coal/deprecated.hh>
 
 #define COAL_BACKWARD_COMPATIBILITY_WITH_HPP_FCL
 
+#ifdef _MSC_VER
 #pragma message COAL_DEPRECATED_HEADER( \
     "Please update your includes from 'hpp/fcl' to 'coal'")
+#else
+#warning "Please update your includes from 'hpp/fcl' to 'coal'"
+#endif
 
 #define HPP_FCL_VERSION_AT_LEAST(major, minor, patch) \
   COAL_VERSION_AT_LEAST(major, minor, patch)
 
-#endif  // COAL_FWD_HH
+#endif  // COAL_FWD_HPP


### PR DESCRIPTION
Hi,

Here are a couple other fixes for backward compatibility. With this, everything seems fine for pinocchio (devel), crocoddyl & HPP (devel), on Nix (aarch64-darwin / clang + x86_64-linux / gcc) and ubuntu 20.04, 22.04 & 24.04.